### PR TITLE
Placing title below icon on tab item

### DIFF
--- a/src/tab/ExNavigationTabBar.js
+++ b/src/tab/ExNavigationTabBar.js
@@ -77,9 +77,9 @@ export default class ExNavigationTabBar extends React.Component {
             delayPressIn={0}
             style={[styles.tabItem, isSelected ? item.selectedStyle : item.style]}
             background={item.nativeFeedbackBackground}>
-            {title}
             {icon}
             {badge}
+            {title}
           </TouchableNativeFeedback>
         );
       } else {
@@ -90,9 +90,9 @@ export default class ExNavigationTabBar extends React.Component {
             delayPressIn={0}
             onLongPress={item.onLongPress}>
             <View style={[styles.tabItem, isSelected ? item.selectedStyle : item.style]}>
-              {title}
               {icon}
               {badge}
+              {title}
             </View>
           </TouchableWithoutFeedback>
         );


### PR DESCRIPTION
Both on iOS and Android, the default tab bars have the text below the icons (rather than above it). This is also what deprecated ex-navigator package did and is a far more sensible default.