### PR TITLE
Hide overflow for SlidingTabView

### DIFF
--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -308,5 +308,6 @@ export default createNavigatorComponent(ExNavigationSlidingTab);
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    overflow: 'hidden',
   },
 });


### PR DESCRIPTION
react-native-tab-view renders tabs as sheets next to each other by default. So the inactive tabs are visible outside the screen's bounds unless we hide the overflow.

Fixes #70