### PR TITLE
Make FloatHorizontal default apply only opacity to navbar items

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -42,7 +42,7 @@ import type { ExNavigationConfig, ExNavigationState } from './ExNavigationTypeDe
 import type { ExNavigationTabContext } from './tab/ExNavigationTab';
 
 const DEFAULT_ROUTE_CONFIG: ExNavigationConfig = {
-  styles: Platform.OS !== 'android' ? NavigationStyles.FloatHorizontal : NavigationStyles.Fade,
+  styles: Platform.OS !== 'android' ? NavigationStyles.SlideHorizontal : NavigationStyles.Fade,
 };
 
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : (global.__exponent ? 24 : 0);

--- a/src/ExNavigationStackItem.js
+++ b/src/ExNavigationStackItem.js
@@ -41,13 +41,13 @@ export default class ExNavigationStackItem extends PureComponent {
 
     if (sceneAnimations === undefined) {
       // fall back to default style.
-      sceneAnimations = NavigationStyles.FloatHorizontal.sceneAnimations(this.props);
+      sceneAnimations = NavigationStyles.SlideHorizontal.sceneAnimations(this.props);
     } else {
       sceneAnimations = sceneAnimations(this.props);
     }
     if (gestures === undefined) {
       // fall back to default pan handlers.
-      gestures = NavigationStyles.FloatHorizontal.gestures && NavigationStyles.FloatHorizontal.gestures(this.props);
+      gestures = NavigationStyles.SlideHorizontal.gestures && NavigationStyles.SlideHorizontal.gestures(this.props);
     } else if (typeof gestures === 'function') {
       gestures = gestures(this.props);
     }

--- a/src/ExNavigationStyles.js
+++ b/src/ExNavigationStyles.js
@@ -108,7 +108,7 @@ function customForHorizontal(props: NavigationSceneRendererProps): Object {
   };
 }
 
-export const FloatHorizontal: ExNavigationStyles = {
+export const FloatHorizontalIOS: ExNavigationStyles = {
   configureTransition: configureSpringTransition,
   sceneAnimations: customForHorizontal,
   navigationBarAnimations: {
@@ -198,6 +198,114 @@ export const FloatHorizontal: ExNavigationStyles = {
         opacity: position.interpolate({
           inputRange: [index - 1, index, index + 1],
           outputRange: [0, barVisibleForSceneIndex(scenes, index) ? 1 : 0, 0],
+        }),
+      };
+    },
+  },
+  gestures: CardStackPanResponder.forHorizontal,
+};
+
+export const FloatHorizontal: ExNavigationStyles = {
+  configureTransition: configureSpringTransition,
+  sceneAnimations: customForHorizontal,
+  navigationBarAnimations: {
+    forContainer: (props, delta) => {
+      const {
+        layout,
+        position,
+        scene,
+        scenes,
+      } = props;
+
+      const index = scene.index;
+
+      const meVisible = barVisibleForSceneIndex(scenes, index);
+      let offset = layout.initWidth;
+      if (delta === 0) {
+        // default state
+        offset = meVisible ? offset : -offset;
+      } else {
+        // if we're pushing, get the previous scenes' visibility. If we're popping, get the scene ahead
+        const prevVisible = barVisibleForSceneIndex(scenes, index + (delta > 0 ? -1 : 1));
+        if (!prevVisible && meVisible) {
+          // when showing, if a push, move from right to left, otherwise if pop, move from left to right
+          offset = delta > 0 ? offset : -offset;
+        } else {
+          // when hiding, if a push, move from left to right, otherwise if a pop, move from right to left
+          offset = delta > 0 ? -offset : offset;
+        }
+      }
+
+      return {
+        transform: [
+          {
+            translateX: position.interpolate({
+              inputRange: [index - 1, index, index + 1],
+              outputRange: [
+                barVisibleForSceneIndex(scenes, index - 1) ? 0 : offset,
+                barVisibleForSceneIndex(scenes, index) ? 0 : offset,
+                barVisibleForSceneIndex(scenes, index + 1) ? 0 : offset,
+              ],
+            }),
+          },
+        ],
+      };
+    },
+    /**
+     * Crossfade the left view
+     */
+    forLeft: (props) => {
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index - 0.3, index, index + 0.3, index + 1],
+          outputRange: [
+            0,
+            barVisibleForSceneIndex(scenes, index) ? 0.05 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 1 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 0.3 : 0,
+            0
+          ],
+        }),
+      };
+    },
+    /**
+     * Crossfade the title
+     */
+    forCenter: (props) => {
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index - 0.3, index, index + 0.3, index + 1],
+          outputRange: [
+            0,
+            barVisibleForSceneIndex(scenes, index) ? 0.1 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 1 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 0.3 : 0,
+            0
+          ],
+        }),
+      };
+    },
+    /**
+     * Crossfade the right view
+     */
+    forRight: (props) => {
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index - 0.3, index, index + 0.3, index + 1],
+          outputRange: [
+            0,
+            barVisibleForSceneIndex(scenes, index) ? 0.05 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 1 : 0,
+            barVisibleForSceneIndex(scenes, index) ? 0.3 : 0,
+            0
+          ],
         }),
       };
     },

--- a/src/ExNavigationStyles.js
+++ b/src/ExNavigationStyles.js
@@ -108,7 +108,7 @@ function customForHorizontal(props: NavigationSceneRendererProps): Object {
   };
 }
 
-export const FloatHorizontalIOS: ExNavigationStyles = {
+export const SlideHorizontalIOS: ExNavigationStyles = {
   configureTransition: configureSpringTransition,
   sceneAnimations: customForHorizontal,
   navigationBarAnimations: {
@@ -205,7 +205,7 @@ export const FloatHorizontalIOS: ExNavigationStyles = {
   gestures: CardStackPanResponder.forHorizontal,
 };
 
-export const FloatHorizontal: ExNavigationStyles = {
+export const SlideHorizontal: ExNavigationStyles = {
   configureTransition: configureSpringTransition,
   sceneAnimations: customForHorizontal,
   navigationBarAnimations: {
@@ -312,6 +312,13 @@ export const FloatHorizontal: ExNavigationStyles = {
   },
   gestures: CardStackPanResponder.forHorizontal,
 };
+
+// TODO: this will become the Android style horizontal float transition (see
+// the Twitter Android app for an example)
+//
+// We can bump minor version and indicate breaking change when we implement
+// this, but no need to do that yet.
+export const FloatHorizontal = SlideHorizontal;
 
 export const FloatVertical: ExNavigationStyles = {
   configureTransition: configureSpringTransition,


### PR DESCRIPTION
- Rename the old behaviour to FloatHorizontalIOS.
- It's becoming more common for apps on iOS to cross-fade the navigation components and not apply translateX like UINavigationController does by default. See: Facebook, Twitter, Instagram.
- This is hard to get it feeling 100% like UINavigationController, and while we should do that, let's be clear that it is an iOS specific look and feel.
- Default to this fade animation which in my opinion is more tasteful.