### PR TITLE
Pass down drawerStyle from drawer to drawerLayout

### DIFF
--- a/src/drawer/ExNavigationDrawerLayout.js
+++ b/src/drawer/ExNavigationDrawerLayout.js
@@ -58,7 +58,7 @@ export default class ExNavigationDrawerLayout extends React.Component {
 
   _renderNavigationView = () => {
     return (
-      <View style={styles.navigationViewContainer}>
+      <View style={[styles.navigationViewContainer, this.props.style]}>
         <View>
           {this.props.renderHeader()}
         </View>


### PR DESCRIPTION
Fix for `<DrawerNavigation drawerStyle={styles.drawer} />` which currently doesn't apply the drawer style