### PR TITLE
Add warning for ExponentJS setup to get correct statusbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ import {
   View,
 } from 'react-native';
 
-/** If you're using ExponentJS, uncomment the line below to import Exponent
-  * BEFORE importing `@exponent/ex-navigation`. This sets the status bar
-  * offsets properly.
-  */
+/**
+ *If you're using Exponent, uncomment the line below to import Exponent
+ * BEFORE importing `@exponent/ex-navigation`. This sets the status bar
+ * offsets properly.
+ */
 // import Exponent from 'exponent';
 
 import {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import {
 } from 'react-native';
 
 /**
- *If you're using Exponent, uncomment the line below to import Exponent
+ * If you're using Exponent, uncomment the line below to import Exponent
  * BEFORE importing `@exponent/ex-navigation`. This sets the status bar
  * offsets properly.
  */

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ import {
   View,
 } from 'react-native';
 
+/** If you're using ExponentJS, uncomment the line below to import Exponent
+  * BEFORE importing `@exponent/ex-navigation`. This sets the status bar
+  * offsets properly.
+  */
+// import Exponent from 'exponent';
+
 import {
   createRouter,
   NavigationProvider,


### PR DESCRIPTION
If you import in the reverse order, the status bar padding will be incorrect.