### PR TITLE
Export TabBar

### DIFF
--- a/src/ExNavigation.js
+++ b/src/ExNavigation.js
@@ -9,6 +9,7 @@ export { default as StackNavigation } from './ExNavigationStack';
 
 export { default as TabNavigation } from './tab/ExNavigationTab';
 export { default as TabNavigationItem } from './tab/ExNavigationTabItem';
+export { default as TabBar } from './tab/ExNavigationTabBar';
 export { default as TabBadge } from './ExNavigationBadge';
 
 export { default as SlidingTabNavigation } from './sliding-tab/ExNavigationSlidingTab';


### PR DESCRIPTION
I needed to wrap the standard TabBar in `renderTabBar` in order to animate hiding/showing it. 

If you don't feel like exporting this, would you consider a PR to support say a `visible` property on `TabNavigation` which gets propagated down to the tab bar, and perhaps a plain default Animation to begin with?