### PR TITLE
Allow navigationBar tintColor property to be a function

### DIFF
--- a/src/ExNavigationRouter.js
+++ b/src/ExNavigationRouter.js
@@ -139,7 +139,11 @@ export class ExNavigationRoute {
   };
 
   getBarTintColor = () => {
-    return _.get(this.config, 'navigationBar.tintColor');
+    const tintColor = _.get(this.config, 'navigationBar.tintColor');
+    if (typeof tintColor === 'function') {
+      return tintColor(this.params, this.config);
+    }
+    return tintColor;
   };
 
   getTitleStyle = () => {


### PR DESCRIPTION
This PR allows passing a function to dynamically set the the `tintColor` property in the `navigationBar` config (basically just mimics the same functionality as `backgroundColor`).

Let me know if there's any way I can be of assistance to get this merged :)