### PR TITLE
Enable tabs to be have dynamic content

### DIFF
--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -134,10 +134,9 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
   }
 
   componentWillReceiveProps(nextProps) {
-    // TODO: Should make it possible to dynamically add children after initial render?
-    // if (nextProps.children && nextProps.children !== this.props.children) {
-    //   this._parseTabItems(nextProps);
-    // }
+    if (nextProps.children && nextProps.children !== this.props.children) {
+      this._parseTabItems(nextProps);
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Allows the tab to re-render when the content changes. F.e. in situations when the content is coming down as a prop from global state (redux store).