### PR TITLE
 "@exponent/ex-navigation" Path was wrong in example-shared-element-transitions

### DIFF
--- a/example-shared-element-transitions/package.json
+++ b/example-shared-element-transitions/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "main.js",
   "dependencies": {
-    "@exponent/ex-navigation": "file:../../",
+    "@exponent/ex-navigation": "file:../",
     "exponent": "^9.0.0",
     "lodash": "^4.13.1",
     "react": "~15.2.1",


### PR DESCRIPTION
Fix Path of @exponent/ex-navigation: file:../ in example-shared-element-transitions/package.json
@skevy @ide @brentvatne @expbot 