### PR TITLE
Set Navigator UID For Current Item When Jumping To An Item In The Drawer

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -359,6 +359,9 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
       if (parentNavigator.type === 'tab') {
         ((parentNavigator: any): ExNavigationTabContext).setNavigatorUIDForCurrentTab(this.state.navigatorUID);
       }
+      else if(parentNavigator.type === 'drawer') {
+        ((parentNavigator: any): ExNavigationDrawerContext).setNavigatorUIDForCurrentItem(this.state.navigatorUID);
+      }
     }
 
 


### PR DESCRIPTION
This should fix #171. `setNavigatorUIDForCurrentItem` is now called when jumping to an item in the drawer. `EX_NAVIGATION.SET_CURRENT_NAVIGATOR` will now fire, allowing navigation actions from outside of a component (e.g in a saga)