### PR TITLE
Added backgroundImage prop to set backgroundImage on NavigationBar

### DIFF
--- a/example/components/CustomNavigationBarExample.js
+++ b/example/components/CustomNavigationBarExample.js
@@ -1,12 +1,18 @@
 import React, { Component } from 'react';
 import {
   View,
+  Text,
   StyleSheet,
+  Platform,
+  Dimensions,
+  Image,
 } from 'react-native';
-import ListItem from './ListItem';
 import { Router } from '../main';
+import ListItem from './ListItem';
 
-export default class HomeScreen extends Component {
+const window = Dimensions.get('window');
+
+export default class CustomNavigationBarExample extends Component {
   /**
     * This is where we can define any route configuration for this
     * screen. For example, in addition to the navigationBar title we
@@ -14,7 +20,9 @@ export default class HomeScreen extends Component {
     */
   static route = {
     navigationBar: {
-      title: 'Examples',
+      title: 'Custom NavigationBar',
+      tintColor: "#FFF",
+      renderBackground: (props) => <View style={[{width: window.width }]}><Image style={[styles.bgImage]} source={{uri: 'http://il9.picdn.net/shutterstock/videos/3951179/thumb/1.jpg'}} resizeMode={'cover'} /></View>,
     },
   }
 
@@ -25,6 +33,7 @@ export default class HomeScreen extends Component {
   render() {
     return (
       <View style={styles.container}>
+        <Text style={styles.title}>Examples</Text>
         <ListItem
           title="Tab Navigation"
           description="iOS style tab bar based navigation"
@@ -40,21 +49,6 @@ export default class HomeScreen extends Component {
           description="Local alert bars for showing temporary messages"
           onPress={this._goToScreen('alertBarsExample')}
         />
-        <ListItem
-          title="Translucent Bars"
-          description="Blurred translucent navigation and tab bar on iOS"
-          onPress={this._goToScreen('translucentBarExample')}
-        />
-        <ListItem
-          title="Event Emitter"
-          description="Communication with navigation bar using events"
-          onPress={this._goToScreen('eventEmitterExample')}
-        />
-        <ListItem
-          title="Custom NavigationBar"
-          description="Custom Navigationbar background using renderBackground"
-          onPress={this._goToScreen('customNavigationBarExample')}
-        />
       </View>
     );
   }
@@ -64,5 +58,20 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fafafa',
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 32,
+    margin: 8,
+  },
+  version: {
+    fontSize: 18,
+  },
+  bgImage: {
+    top: 0,
+    left: 0,
+    right: 0,
+    height: Platform.OS === 'ios' ? 64 : 65,
+    width: window.width,   
   },
 });

--- a/example/main.js
+++ b/example/main.js
@@ -9,6 +9,7 @@ import SlidingTabNavigationExample from './components/SlidingTabNavigationExampl
 import AlertBarsExample from './components/AlertBarsExample';
 import TranslucentBarExample from './components/TranslucentBarExample';
 import EventEmitterExample from './components/EventEmitterExample';
+import CustomNavigationBarExample from './components/CustomNavigationBarExample';
 
 import {
   createRouter,
@@ -37,6 +38,7 @@ export const Router = createRouter(() => ({
   alertBarsExample: () => AlertBarsExample,
   translucentBarExample: () => TranslucentBarExample,
   eventEmitterExample: () => EventEmitterExample,
+  customNavigationBarExample: () => CustomNavigationBarExample,
 }));
 
 class App extends Component {

--- a/src/ExNavigationBar.js
+++ b/src/ExNavigationBar.js
@@ -7,6 +7,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Dimensions,
 } from 'react-native';
 import PureComponent from './utils/PureComponent';
 import { unsupportedNativeView } from './ExUnsupportedNativeView';
@@ -31,6 +32,8 @@ const BACKGROUND_COLOR = Platform.OS === 'ios' ? '#EFEFF2' : '#FFF';
 const BORDER_BOTTOM_COLOR = 'rgba(0, 0, 0, .15)';
 const BORDER_BOTTOM_WIDTH = Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 0;
 const BACK_BUTTON_HIT_SLOP = { top: 0, bottom: 0, left: 0, right: 30 };
+
+const window = Dimensions.get('window');
 
 class ExNavigationBarTitle extends PureComponent {
   render() {
@@ -219,6 +222,7 @@ export default class ExNavigationBar extends PureComponent {
 
     // TODO: this should come from the latest scene config
     const height = this.props.barHeight + this.props.statusBarHeight;
+    const backgroundImage = this.props.backgroundImage;
 
     let styleFromRouteConfig = this.props.latestRoute.getBarStyle();
     let isTranslucent = !!this.props.latestRoute.getTranslucent();
@@ -245,6 +249,7 @@ export default class ExNavigationBar extends PureComponent {
         {isTranslucent && <Components.BlurView style={[styles.translucentUnderlay, {height}]} />}
 
         <Animated.View style={containerStyle}>
+          {isTranslucent ? null : <Image style={[styles.backgroundImage, {height}]} source={backgroundImage} />}
           <View style={[styles.appbarInnerContainer, {top: this.props.statusBarHeight}]}>
             {titleComponents}
             {leftComponents}
@@ -393,6 +398,14 @@ const styles = StyleSheet.create({
   },
   appbarTranslucent: {
     backgroundColor: 'rgba(255,255,255,0.7)',
+  },
+  backgroundImage: {
+    top:0,
+    left:0,
+    right:0,
+    position: 'absolute',
+    resizeMode: 'cover', 
+    width: window.width,
   },
   appbarInnerContainer: {
     position: 'absolute',

--- a/src/ExNavigationRouter.js
+++ b/src/ExNavigationRouter.js
@@ -179,6 +179,14 @@ export class ExNavigationRoute {
     return result;
   };
 
+  getBarBackgroundImage = () => {
+    const backgroundImage = _.get(this.config, 'navigationBar.backgroundImage');
+    if (typeof backgroundImage === 'function') {
+      return backgroundImage(this.params, this.config);
+    }
+    return backgroundImage;
+  };
+
   clone() {
     return new ExNavigationRoute({
       key: this.key,

--- a/src/ExNavigationRouter.js
+++ b/src/ExNavigationRouter.js
@@ -179,14 +179,6 @@ export class ExNavigationRoute {
     return result;
   };
 
-  getBarBackgroundImage = () => {
-    const backgroundImage = _.get(this.config, 'navigationBar.backgroundImage');
-    if (typeof backgroundImage === 'function') {
-      return backgroundImage(this.params, this.config);
-    }
-    return backgroundImage;
-  };
-
   clone() {
     return new ExNavigationRoute({
       key: this.key,

--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -500,9 +500,6 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
       latestRouteConfig.navigationBar &&
       latestRouteConfig.navigationBar.visible !== false;
 
-    // Get backgroundImage from props
-    const backgroundImage = latestRouteConfig.navigationBar.backgroundImage;  
-
     // TODO: add height and statusBarHeight options here
 
     return (
@@ -515,7 +512,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
         renderLeftComponent={this._renderLeftComponentForHeader}
         renderTitleComponent={this._renderTitleComponentForHeader}
         renderRightComponent={this._renderRightComponentForHeader}
-        backgroundImage={backgroundImage}
+        renderBackgroundComponent={this._renderBackgroundComponentForHeader}
       />
     );
   };
@@ -538,6 +535,17 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
     }
 
     return result;
+  }
+
+  _renderBackgroundComponentForHeader = (props) => { //eslint-disable-line react/display-name
+    const { scene: { route } } = props;
+    const routeConfig = route.config;
+
+     if (routeConfig.navigationBar && typeof routeConfig.navigationBar.renderBackground === 'function') {
+      return routeConfig.navigationBar.renderBackground(route, props);
+    }
+
+    return null;
   }
 
   _renderLeftComponentForHeader = (props) => { //eslint-disable-line react/display-name

--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -500,6 +500,9 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
       latestRouteConfig.navigationBar &&
       latestRouteConfig.navigationBar.visible !== false;
 
+    // Get backgroundImage from props
+    const backgroundImage = latestRouteConfig.navigationBar.backgroundImage;  
+
     // TODO: add height and statusBarHeight options here
 
     return (
@@ -512,6 +515,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
         renderLeftComponent={this._renderLeftComponentForHeader}
         renderTitleComponent={this._renderTitleComponentForHeader}
         renderRightComponent={this._renderRightComponentForHeader}
+        backgroundImage={backgroundImage}
       />
     );
   };

--- a/src/ExNavigationTypeDefinition.js.flow
+++ b/src/ExNavigationTypeDefinition.js.flow
@@ -40,6 +40,7 @@ export type ExNavigationBarConfig = {
   titleStyle?: Object | number,
   tintColor?: string,
   backgroundColor?: string | Function,
+  backgroundImage?: string | Function,
   borderBottomWidth?: number,
   elevation?: number,
   borderBottomColor?: string,

--- a/src/ExNavigationTypeDefinition.js.flow
+++ b/src/ExNavigationTypeDefinition.js.flow
@@ -40,7 +40,6 @@ export type ExNavigationBarConfig = {
   titleStyle?: Object | number,
   tintColor?: string,
   backgroundColor?: string | Function,
-  backgroundImage?: string | Function,
   borderBottomWidth?: number,
   elevation?: number,
   borderBottomColor?: string,
@@ -49,6 +48,7 @@ export type ExNavigationBarConfig = {
   renderLeft?: (state: ExNavigationState, props: NavigationSceneRendererProps) => ?React.Element<{}>,
   renderTitle?: (state: ExNavigationState, props: NavigationSceneRendererProps) => ?React.Element<{}>,
   renderRight?: (state: ExNavigationState, props: NavigationSceneRendererProps) => ?React.Element<{}>,
+  renderBackground?: (state: ExNavigationState, props: NavigationSceneRendererProps) => ?React.Element<{}>,
 };
 
 export type ExNavigationDrawerConfig = {


### PR DESCRIPTION
@skevy as we talk yesterday I have added a Particularly `<Image />` Component to NavigationBar which has a prop calls backgroundImage which user can access it from navigationBar = { backgroundImage: require('../assets/paintbrush.jpg') } it Works well with every cases that you have implemented but if user provided a backgroundImage prop it'll render an Image in between Container and innerContainer. And if anyone still want to use Translucent (BlurView) Navigation that should work like if navigationBar = { translucent: true } it'll not render backgroundImage.

@satya164 @brentvatne
If you guys have some time please look at it and let me know if it works for us!!  