### PR TITLE
Better error message when initialTab on TabNavigation doesn't

### DIFF
--- a/src/tab/ExNavigationTab.js
+++ b/src/tab/ExNavigationTab.js
@@ -56,7 +56,7 @@ export class ExNavigationTabContext extends ExNavigatorContext {
 type TabItem = {
   id: string,
   renderIcon?: Function,
-  renderBadge?: Function,  
+  renderBadge?: Function,
   tabContent?: React.Element<{}>,
 };
 
@@ -176,6 +176,12 @@ class ExNavigationTab extends PureComponent<any, Props, State> {
   }
 
   renderTab(tabItem: Object) {
+    // Check if initialTab matches any actual TabItems
+    invariant(tabItem,
+      `Invalid initialTab=${this.state.renderedTabKeys[0]} ` +
+      `Please check your TabNavigation initialTab`,
+    );
+
     if (!tabItem.element) {
       return null;
     }


### PR DESCRIPTION
match any actual TabItems

fix exponentjs/ex-navigation#72