### PR TITLE
Accept 2 new props for DrawerItems (disabled, handlesDrawerToggle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .exponent
 lib/
+.idea

--- a/README.md
+++ b/README.md
@@ -555,6 +555,8 @@ const styles = StyleSheet.create({
 });
 ```
 
+See [ExNavigationDrawerLayout](https://github.com/exponentjs/ex-navigation/blob/master/src/drawer/ExNavigationDrawerLayout.js)
+to discover which props you can pass to `DrawerNavigationItem`.
 
 ### Integrate with your existing Redux store
 

--- a/src/drawer/ExNavigationDrawerLayout.js
+++ b/src/drawer/ExNavigationDrawerLayout.js
@@ -133,7 +133,10 @@ export default class ExNavigationDrawerLayout extends React.Component {
   //
   _handlePress = (item: any) => {
     item.onPress();
-    this._component.closeDrawer();
+
+    if (!item.handlesDrawerToggle) {
+      this._component.closeDrawer();
+    }
   }
 
   _handleLongPress = (item: any) => {
@@ -142,7 +145,10 @@ export default class ExNavigationDrawerLayout extends React.Component {
     }
 
     item.onLongPress();
-    this._component.closeDrawer();
+
+    if (!item.handlesDrawerToggle) {
+      this._component.closeDrawer();
+    }
   }
 }
 

--- a/src/drawer/ExNavigationDrawerLayout.js
+++ b/src/drawer/ExNavigationDrawerLayout.js
@@ -76,13 +76,13 @@ export default class ExNavigationDrawerLayout extends React.Component {
     }
 
     return this.props.items.map((item, index) => {
-      let { renderIcon, renderTitle, renderRight } = item;
+      let { renderIcon, renderTitle, renderRight, disabled } = item;
       let isSelected = this.props.selectedItem === item.id;
-      const icon = renderIcon && renderIcon(isSelected);
-      const title = renderTitle && renderTitle(isSelected);
-      const rightElement = renderRight && renderRight(isSelected);
+      const icon = renderIcon && renderIcon(isSelected, disabled);
+      const title = renderTitle && renderTitle(isSelected, disabled);
+      const rightElement = renderRight && renderRight(isSelected, disabled);
 
-      if (item.showsTouches !== false) {
+      if (item.showsTouches !== false && !disabled) {
         return (
           <TouchableNativeFeedbackSafe
             key={index}
@@ -108,6 +108,7 @@ export default class ExNavigationDrawerLayout extends React.Component {
         return (
           <TouchableWithoutFeedback
             key={index}
+            disabled={disabled}
             onPress={() => { this._handlePress(item); }}
             onLongPress={() => { this._handleLongPress(item); }}>
             <View style={[styles.buttonContainer, isSelected ? item.selectedStyle : item.style]}>


### PR DESCRIPTION
* `disabled`: Passed though to [TouchableWithoutFeedback](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#disabled), as well as to render functions such as `renderTitle`.
* `handlesDrawerToggle`: For items that will handle closing the drawer (or not) themselves after being pressed. If this prop is truthy, these items will not cause the drawer to close automatically.
  * For example, I have a drawer item called "Check Updates" that simply shows a spinner while checking for updates. No route is pushed, and the drawer should not be closed.

Also minorly updates the README with link to relevant source for `DrawerNavigationItem`.

Please let me know if there's any testing or linting you'd like me to do before merging this! Thanks 🌵 