### PR TITLE
Add `paddingBottom` to DrawerLayout container

### DIFF
--- a/src/drawer/ExNavigationDrawerLayout.js
+++ b/src/drawer/ExNavigationDrawerLayout.js
@@ -152,6 +152,7 @@ const styles = StyleSheet.create({
   },
   navigationViewScrollableContentContainer: {
     paddingTop: 8,
+    paddingBottom: 8,
   },
   buttonContainer: {
     flex: 1,


### PR DESCRIPTION
It looks a bit cut off without this padding, e.g. if you have a lot of items in the drawer, or if you rotate into landscape mode. This makes it more consistent.