### PR TITLE
Update ExNavigationRouter.js

### DIFF
--- a/src/ExNavigationRouter.js
+++ b/src/ExNavigationRouter.js
@@ -210,7 +210,8 @@ export class ExNavigationRouter<RC: RouteCreator> {
       warning(
         _isSerializable(routeParams),
         'You passed a non-serializable value as route parameters. This may prevent navigation state ' +
-        'from being saved and restored properly.'
+        'from being saved and restored properly. This is only relevant if you plan to implement ' +
+        'resuming your app to where the user quit it last time.'
       );
     }
 


### PR DESCRIPTION
This might save some questions.
From slack conversation with @brentvatne:

> "You passed a non-serializable value as route parameters. This may prevent navigation state from being saved and restored properly." Does this affect app at runtime or is this for cases when an app should resume where user quit last time?

> ^ correct
usually this means you’re passing something like a function as a route param 
this isn’t always a useful warning, sometimes you don’t care about that
a lot of the time