### PR TITLE
Unsubcribe to store in SharedElementOverlay, fix flow types

### DIFF
--- a/src/shared-element/ExNavigationSharedElement.js
+++ b/src/shared-element/ExNavigationSharedElement.js
@@ -16,7 +16,7 @@ type Props = {
 
   // This is not part of the public API and is used by the overlay to pass down
   // transition info used by the animation.
-  transitionProps: ?TransitionProps,
+  transitionProps?: ?TransitionProps,
 };
 
 export default class SharedElement extends Component {

--- a/src/shared-element/ExNavigationSharedElementGroup.js
+++ b/src/shared-element/ExNavigationSharedElementGroup.js
@@ -24,7 +24,7 @@ import type {
 const DEFAULT_TRANSITION = {
   timing: Animated.timing,
   easing: Easing.inOut(Easing.ease),
-  duration: 500,
+  duration: 400,
 };
 
 type TransitionFn = (
@@ -41,15 +41,15 @@ type State = {
 
 type Props = {
   id: string,
-  children: React.Element<*>,
-  configureTransition: ?((
+  children?: React.Element<*>,
+  configureTransition?: ?((
     a: NavigationTransitionProps,
     b: ?NavigationTransitionProps,
   ) => NavigationTransitionSpec),
-  sceneAnimations: ?((props: NavigationSceneRendererProps) => Object),
-  navigationBarAnimations: ?((props: NavigationSceneRendererProps) => Object),
-  onTransitionStart: ?TransitionFn,
-  onTransitionEnd: ?TransitionFn,
+  sceneAnimations?: ?((props: NavigationSceneRendererProps) => Object),
+  navigationBarAnimations?: ?((props: NavigationSceneRendererProps) => Object),
+  onTransitionStart?: ?TransitionFn,
+  onTransitionEnd?: ?TransitionFn,
 };
 
 export default class SharedElementGroup extends Component {

--- a/src/shared-element/ExNavigationSharedElementOverlay.js
+++ b/src/shared-element/ExNavigationSharedElementOverlay.js
@@ -14,7 +14,9 @@ import storeShape from 'react-redux/lib/utils/storeShape';
 
 import SharedElementReducer from './ExNavigationSharedElementReducer';
 
-type Props = {};
+type Props = {
+  children?: ?React.Element<*>,
+};
 
 type State = {
   visible: boolean,
@@ -24,9 +26,18 @@ type State = {
   progress: ?mixed,
 };
 
-const store = createStore(SharedElementReducer);
+const sharedElementStore = createStore(SharedElementReducer);
 
 export default class SharedElementOverlay extends React.Component {
+  static getStore() {
+    return sharedElementStore;
+  }
+
+  static childContextTypes = {
+    sharedElementStore: storeShape,
+  }
+
+  props: Props;
   state: State = {
     visible: false,
     elementGroups: {},
@@ -36,28 +47,13 @@ export default class SharedElementOverlay extends React.Component {
   };
 
   _innerViewRef: React.Element<*>;
-
-  static getStore() {
-    return store;
-  }
-
   _store: Object;
-
-  static childContextTypes = {
-    sharedElementStore: storeShape,
-  }
+  _unsubscribe: ?Function;
 
   constructor(props: Props) {
     super(props);
+
     this._store = SharedElementOverlay.getStore();
-    this._store.subscribe(() => {
-      const state = this._store.getState();
-      this.setState({
-        ...state,
-        visible: state.transitioningElementGroupFromUid &&
-          state.transitioningElementGroupToUid && state.toViewReady,
-      });
-    });
   }
 
   getChildContext() {
@@ -66,15 +62,24 @@ export default class SharedElementOverlay extends React.Component {
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return nextState.visible !== this.state.visible;
-  }
-
   componentDidMount() {
+    this._unsubscribe = this._store.subscribe(() => {
+      const state = this._store.getState();
+      this.setState({
+        ...state,
+        visible: state.transitioningElementGroupFromUid &&
+          state.transitioningElementGroupToUid && state.toViewReady,
+      });
+    });
+
     this._store.dispatch({
       type: 'SET_OVERLAY_HANDLE',
       handle: findNodeHandle(this._innerViewRef),
     });
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe && this._unsubscribe();
   }
 
   render() {


### PR DESCRIPTION
SharedElementOverlay leaked subscriptions and caused some setState warnings. Also cleaned up flow types and moved some code.