### PR TITLE
Hotfix- Changing positon="bottom" would not work

### DIFF
--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -47,6 +47,7 @@ type Props = {
   pressColor?: string,
   renderBefore: () => ?React.Element<any>,
   renderHeader?: (props: any) => ?React.Element<any>,
+  renderFooter?: (props: any) => ?React.Element<any>,
   renderLabel?: (routeParams: any) => ?React.Element<any>,
   style?: any,
   swipeEnabled?: boolean,
@@ -181,8 +182,8 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
         navigationState={navigationState}
         renderScene={this._renderScene}
         renderPager={this._renderPager}
-        renderHeader={this.props.renderHeader || (this.props.position !== 'bottom' ? this._renderHeader : undefined)}
-        renderFooter={this.props.renderFooter || (this.props.position === 'bottom' ? this._renderHeader : undefined)}
+        renderHeader={this.props.renderHeader || (this.props.position !== 'bottom' ? this._renderTabBar : undefined)}
+        renderFooter={this.props.renderFooter || (this.props.position === 'bottom' ? this._renderTabBar : undefined)}
         onRequestChangeTab={this._setActiveTab}
       />
     );
@@ -206,8 +207,8 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
     }
   };
 
-  _renderHeader = (props) => {
-    const TabBarComponent = this.props.position === 'top' ? TabBarTop : TabBar;
+  _renderTabBar = (props) => {
+    const TabBarComponent = this.props.position === 'top' || 'bottom' ? TabBarTop : TabBar;
     const tabBarProps = {
       pressColor: this.props.pressColor,
       indicatorStyle: this.props.indicatorStyle,

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -208,7 +208,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
   };
 
   _renderTabBar = (props) => {
-    const TabBarComponent = this.props.position === 'top' || 'bottom' ? TabBarTop : TabBar;
+    const TabBarComponent = this.props.position === 'top' ? TabBarTop : TabBar;
     const tabBarProps = {
       pressColor: this.props.pressColor,
       indicatorStyle: this.props.indicatorStyle,

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -181,7 +181,8 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
         navigationState={navigationState}
         renderScene={this._renderScene}
         renderPager={this._renderPager}
-        renderHeader={this.props.renderHeader || this._renderHeader}
+        renderHeader={this.props.renderHeader || (this.props.position !== 'bottom' ? this._renderHeader : undefined)}
+        renderFooter={this.props.renderFooter || (this.props.position === 'bottom' ? this._renderHeader : undefined)}
         onRequestChangeTab={this._setActiveTab}
       />
     );


### PR DESCRIPTION
When using ExNav and trying to make the sliding nav tab bar appear at the bottom, it would stay at the top, the following fix allows it to work as intended, with help from satya164