### PR TITLE
Add augmentScene prop

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -53,6 +53,7 @@ type TransitionFn = (
 ) => void;
 
 type Props = {
+  augmentScene?: (scene: ReactElement<any>, route: Object) => ReactElement<any>,
   defaultRouteConfig?: ExNavigationConfig,
   id: string,
   initialRoute?: ExNavigationRoute,
@@ -669,7 +670,10 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
 
   _renderRoute = (props: ExNavigationSceneRendererProps) => {
     const route: ExNavigationRoute = props.route;
-    const routeElement = route.render();
+    let routeElement = route.render();
+    if (this.props.augmentScene) {
+      routeElement = this.props.augmentScene(routeElement, route);
+    }
 
     let routeElementProps = {};
 


### PR DESCRIPTION
Old `ex-navigator` had a neat prop called [`augmentScene`](https://github.com/exponentjs/ex-navigator/blob/20755e32516dc83786a779e8b47f1f63f167a7f5/ExNavigator.js#L39) that allowed one to augment the rendered scene element with whatever custom need one had. This PR ports this functionality over to the `StackNavigation` component. 