### PR TITLE
Import findNodeHandle from ReactNative

### DIFF
--- a/src/shared-element/ExNavigationSharedElement.js
+++ b/src/shared-element/ExNavigationSharedElement.js
@@ -3,9 +3,9 @@
  */
 
 import React, { Component, PropTypes, cloneElement } from 'react';
-import findNodeHandle from 'react/lib/findNodeHandle';
 import {
   UIManager,
+  findNodeHandle,
 } from 'react-native';
 
 import type { TransitionProps, Metrics } from './ExNavigationSharedElementReducer';

--- a/src/shared-element/ExNavigationSharedElementOverlay.js
+++ b/src/shared-element/ExNavigationSharedElementOverlay.js
@@ -3,10 +3,10 @@
  */
 
 import React, { cloneElement } from 'react';
-import findNodeHandle from 'react/lib/findNodeHandle';
 import {
   View,
   StyleSheet,
+  findNodeHandle,
 } from 'react-native';
 
 import { createStore } from 'redux';


### PR DESCRIPTION
`react/lib/findNodeHandle` doesn't exist in react 15.4, import from RN directly instead.