### PR TITLE
Allow setting statusBar height via route config

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -469,9 +469,13 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
   _getNavigationBarHeight(latestRouteConfig) {
     let height = NavigationBar.DEFAULT_HEIGHT;
 
-    if (latestRouteConfig.statusBar && latestRouteConfig.statusBar.translucent) {
-      height = NavigationBar.DEFAULT_HEIGHT_WITHOUT_STATUS_BAR + DEFAULT_STATUSBAR_HEIGHT;
-    };
+    if (latestRouteConfig.statusBar) {
+      if (latestRouteConfig.statusBar.height || latestRouteConfig.statusBar.height === 0) {
+        height = NavigationBar.DEFAULT_HEIGHT_WITHOUT_STATUS_BAR + latestRouteConfig.statusBar.height;
+      } else if (latestRouteConfig.statusBar.translucent) {
+        height = NavigationBar.DEFAULT_HEIGHT_WITHOUT_STATUS_BAR + DEFAULT_STATUSBAR_HEIGHT;
+      }
+    }
 
     return height;
   }
@@ -528,8 +532,12 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
 
     // pass the statusBarHeight to headerComponent if statusBar is translucent
     let statusBarHeight = STATUSBAR_HEIGHT;
-    if (latestRouteConfig.statusBar && latestRouteConfig.statusBar.translucent) {
-      statusBarHeight = DEFAULT_STATUSBAR_HEIGHT;
+    if (latestRouteConfig.statusBar) {
+      if (latestRouteConfig.statusBar.height || latestRouteConfig.statusBar.height === 0) {
+        statusBarHeight = latestRouteConfig.statusBar.height;
+      } else if (latestRouteConfig.statusBar.translucent) {
+        statusBarHeight = DEFAULT_STATUSBAR_HEIGHT;
+      }
     }
 
     // TODO: add height here


### PR DESCRIPTION
#### Changes

In the same vein as https://github.com/exponentjs/ex-navigation/pull/104, allow setting the status bar height via route config.

#### Example

```diff
 <StackNavigation
   initialRoute={'home'}
   defaultRouteConfig={{
     navigationBar: {
       backgroundColor: '#fff',
     },
+    statusBar: {
+      height: 0,
+    },
   }}
 />
```

#### Motivation

I use a custom status bar in order to have it appear on top of my entire app, including the drawer and scrim. I feel like this makes the drawer look nicer when it's open (see screenshot). I'm sure there are other use cases for this as well.

![Screenshot of drawer with status bar](https://cloud.githubusercontent.com/assets/2047062/20442946/c71a0bf8-ad98-11e6-80af-903aa790d5df.png)