### PR TITLE
Allow passing null children to NavigationDrawer

### DIFF
--- a/src/drawer/ExNavigationDrawer.js
+++ b/src/drawer/ExNavigationDrawer.js
@@ -260,6 +260,10 @@ class ExNavigationDrawer extends PureComponent<any, Props, State> {
 
   _parseDrawerItems(props) {
     const drawerItems = Children.map(props.children, (child, index) => {
+      if (!child) {
+        return null;
+      }
+
       invariant(
         child.type === ExNavigationDrawerItem,
         'All children of DrawerNavigation must be DrawerNavigationItems.',


### PR DESCRIPTION
Previously this pattern would fail

```
    {debug &&
          <DrawerNavigationItem
            id="test"
            renderTitle={isSelected => {
              return <MenuItem label="Testing" iconName="warning" active={isSelected} />;
            }}
          >
            <StackNavigation
              id="test"
              initialRoute={router.getRoute('test')}
              defaultRouteConfig={{
                navigationBar: {
                  title: () => <Header>Test</Header>,
                  ...defaultNavBarProps,
                },
              }}
            />
          </DrawerNavigationItem>
        }
```

This patch fixes it.