### PR TITLE
[SharedElements] Fix crash when poping to a view that was removed

### DIFF
--- a/src/shared-element/ExNavigationSharedElementGroup.js
+++ b/src/shared-element/ExNavigationSharedElementGroup.js
@@ -200,6 +200,10 @@ export default class SharedElementGroup extends Component {
     prevTransitionProps: NavigationTransitionProps,
     isTransitionTo?: bool = false
   ): void => {
+    if (!this._isMounted) {
+      return;
+    }
+
     const { scene } = transitionProps;
     const { scene: prevScene } = prevTransitionProps;
 


### PR DESCRIPTION
If the SharedElementGroup was removed it would crash because the elements don't exist anymore. This makes it so it just doesn't do the shared element transition and simply fades back to the previous view.