### PR TITLE
Fix flow for children prop

### DIFF
--- a/src/shared-element/ExNavigationSharedElement.js
+++ b/src/shared-element/ExNavigationSharedElement.js
@@ -7,11 +7,12 @@ import {
   UIManager,
   findNodeHandle,
 } from 'react-native';
+import invariant from 'invariant';
 
 import type { TransitionProps, Metrics } from './ExNavigationSharedElementReducer';
 
 type Props = {
-  children: () => React.Element<*>,
+  children?: () => React.Element<*>,
   id: string,
 
   // This is not part of the public API and is used by the overlay to pass down
@@ -43,6 +44,7 @@ export default class SharedElement extends Component {
       );
     }
 
+    invariant(childFn, 'Must pass a function as a child to `SharedElement`.');
     const childEl = childFn(animationStyle);
 
     return cloneElement(childEl, {


### PR DESCRIPTION
Flow doesn't understand jsx + children (https://github.com/facebook/flow/issues/1964) so this makes the prop optional and adds an invariant to make sure it was actually passed.