### PR TITLE
Add renderScene prop to StackNavigation

### DIFF
--- a/src/ExNavigation.js
+++ b/src/ExNavigation.js
@@ -6,6 +6,7 @@ export { default as NavigationProvider } from './ExNavigationProvider';
 export { default as NavigationContext } from './ExNavigationContext';
 
 export { default as StackNavigation } from './ExNavigationStack';
+export { default as StackNavigationItem } from './ExNavigationStackItem';
 
 export { default as TabNavigation } from './tab/ExNavigationTab';
 export { default as TabNavigationItem } from './tab/ExNavigationTabItem';

--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -68,6 +68,7 @@ type Props = {
   onUnregisterNavigatorContext: (navigatorUID: string) => void,
   onTransitionStart: ?TransitionFn,
   onTransitionEnd: ?TransitionFn,
+  renderScene?: (props: StackNavigationSceneRendererProps) => ?React.Element<{}>,
 };
 
 type State = {
@@ -87,6 +88,10 @@ type Context = {
 type ExNavigationSceneRendererProps = {
   route: ExNavigationRoute,
 } & NavigationSceneRendererProps;
+
+type StackNavigationSceneRendererProps = ExNavigationSceneRendererProps & {
+  style?: any,
+};
 
 type TransitionOptions = {
   transitionGroup?: string,
@@ -674,21 +679,27 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
     const latestRouteConfig = latestRoute.config;
     const { sceneAnimations, gestures } = latestRouteConfig.styles || {};
 
-    props = { ...props, latestRouteConfig, latestRoute };
-
     const scene: any = props.scene;
     const routeForScene = scene.route;
 
+    props = {
+      ...props,
+      latestRouteConfig,
+      latestRoute,
+      onNavigateBack: this._onNavigateBack,
+      key: props.scene.key,
+      route: routeForScene,
+      sceneAnimations,
+      gestures,
+      renderScene: this._renderRoute,
+    };
+
+    if (typeof this.props.renderScene === 'function') {
+      return this.props.renderScene(props);
+    }
+
     return (
-      <NavigationItem
-        {...props}
-        onNavigateBack={this._onNavigateBack}
-        key={props.scene.key}
-        route={routeForScene}
-        sceneAnimations={sceneAnimations}
-        gestures={gestures}
-        renderScene={this._renderRoute}
-      />
+      <NavigationItem {...props} />
     );
   };
 


### PR DESCRIPTION
The background color in [ExNavigationStackItem](https://github.com/exponentjs/ex-navigation/blob/68cbb5b082f1ef5e4599686f9168132d8ede7737/src/ExNavigationStackItem.js#L85) was causing some flashes of white in my dark colored application. This was *mostly* fixed by setting a background color using the `sceneStyle` property in `defaultRouteConfig`, but a light vertical line was still shown when transitioning between screens.

This PR adds a `renderScene` prop to `StackNavigation` component that allows overriding props passed to `StackNavigationItem`, including the `style` prop that can be used to set a different background color for `StackNavigationItem`.

`StackNavigationItem` (ExNavigationStackItem) is also now exported in the public API.

An example of usage:
```js
<StackNavigation
  id="root"
  initialRoute={initialRoute}
  renderScene={(props) => <StackNavigationItem {...props} style={styles.navigationItem} />}
  defaultRouteConfig={{
    navigationBar: {
      backgroundColor: '#181818',
      tintColor: '#FFFFFF',
      borderBottomWidth: StyleSheet.hairlineWidth,
      borderBottomColor: '#393939',
    },
    sceneStyle: styles.scene,
  }}
/>
...
const styles = StyleSheet.create({
  scene: {
    backgroundColor: '#0D0D0D',
  },
  navigationItem: {
    backgroundColor: '#0D0D0D',
  }
});

```