### PR TITLE
Add labelStyle prop to SlidingTabNavigation

### DIFF
--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -53,6 +53,7 @@ type Props = {
   swipeEnabled?: boolean,
   tabBarStyle?: any,
   tabStyle?: any,
+  labelStyle?: any,
 };
 
 type State = {
@@ -213,6 +214,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
       pressColor: this.props.pressColor,
       indicatorStyle: this.props.indicatorStyle,
       tabStyle: this.props.tabStyle,
+      labelStyle: this.props.labelStyle,
       renderLabel: this.props.renderLabel,
       style: [{backgroundColor: this.props.barBackgroundColor}, this.props.tabBarStyle],
     };


### PR DESCRIPTION
As soon as you add a new `SlidingTabNavigation` you can't see the tab labels because the default color is `white` and the default background color is `transparent`, so in light backgrounds they disappear.

The only way yet to change it is fully-overriding the `renderLabel` function.
This PR adds the ability to simply change the default `labelStyle`, e.g:

```jsx
<SlidingTabNavigation initialTab="foo" labelStyle={{color: 'black'}}>
  ...
</SlidingTabNavigation>
```