### PR TITLE
default n to 1 while poping in batch mode

### DIFF
--- a/src/ExNavigationContext.js
+++ b/src/ExNavigationContext.js
@@ -160,7 +160,7 @@ export default class NavigationContext {
             Actions.push(uid, route)
           );
         },
-        pop: (n) => {
+        pop: (n = 1) => {
           if (n === 1) {
             actions.push(
               Actions.pop(uid)


### PR DESCRIPTION
@brentvatne @skevy 

default value in exnavContext was missed when adding `pop(n)` feature.

This works fine for those using the navigation to pop. `navigation.pop()` but breaks for those trying to batch using performAction.