### PR TITLE
Make it possible to override the NavigationStackItem's styles

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -672,7 +672,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
     const latestRoute = this._getRouteAtIndex(props.scenes, props.scenes.length - 1);
 
     const latestRouteConfig = latestRoute.config;
-    const { sceneAnimations, gestures } = latestRouteConfig.styles || {};
+    const { sceneAnimations, gestures, style } = latestRouteConfig.styles || {};
 
     props = { ...props, latestRouteConfig, latestRoute };
 
@@ -688,6 +688,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
         sceneAnimations={sceneAnimations}
         gestures={gestures}
         renderScene={this._renderRoute}
+        style={style}
       />
     );
   };


### PR DESCRIPTION
Currently, the ExNavigationStackItem references a style property to override styles, but there didn't seem to be a way to actually pass this through properly.

Updated so that you can now do the following to specify styles for the StackItem:

```
static route = {
    styles: {
        ...NavigationStyles.SlideVertical,
        style: {
            backgroundColor: 'red'
        }
    }
}
```