### PR TITLE
Export Actions Const Too

### DIFF
--- a/src/ExNavigation.js
+++ b/src/ExNavigation.js
@@ -27,6 +27,7 @@ export { default as SharedElement } from './shared-element/ExNavigationSharedEle
 export { createNavigationEnabledStore } from './ExNavigationStore';
 
 export { default as NavigationActions } from './ExNavigationActions';
+export { default as ExNavigationActionTypes } from './ExNavigationActionTypes';
 export { default as NavigationReducer } from './ExNavigationReducer';
 
 export * as NavigationStyles from './ExNavigationStyles';

--- a/src/ExNavigation.js
+++ b/src/ExNavigation.js
@@ -27,7 +27,7 @@ export { default as SharedElement } from './shared-element/ExNavigationSharedEle
 export { createNavigationEnabledStore } from './ExNavigationStore';
 
 export { default as NavigationActions } from './ExNavigationActions';
-export { default as ExNavigationActionTypes } from './ExNavigationActionTypes';
+export { default as NavigationActionTypes } from './ExNavigationActionTypes';
 export { default as NavigationReducer } from './ExNavigationReducer';
 
 export * as NavigationStyles from './ExNavigationStyles';


### PR DESCRIPTION
So that we can use const instead of strings in our custom reducers.

`import { NavigationActionTypes } from '@exponent/ex-navigation';`